### PR TITLE
One rating per student

### DIFF
--- a/app/controllers/ratings_controller.rb
+++ b/app/controllers/ratings_controller.rb
@@ -23,7 +23,7 @@ class RatingsController < ApplicationController
           redirect_to classroom_track_url(@classroom, @track)
         }
         format.js {
-          PrivatePub.publish_to "/track/#{@track.id}/ratings", checkpoint: @checkpoint.id, ratings: @checkpoint.ratings, current_score: @rating.score
+          PrivatePub.publish_to "/track/#{@track.id}/ratings", checkpoint: @checkpoint.id, ratings: @checkpoint.ratings.group(:student_id), current_score: @rating.score
           render json: @rating
         }
       end

--- a/app/models/checkpoint.rb
+++ b/app/models/checkpoint.rb
@@ -6,15 +6,23 @@ class Checkpoint < ActiveRecord::Base
 
   def ratings_count(start_time, end_time, score="all")
     if self.ratings.any?
-      ratings_over_time = self.ratings.where({ created_at: start_time..end_time }).group(:student_id)
+      scoped_ratings = self.ratings.where({ created_at: start_time..end_time }).group(:student_id)
       if score == "all"
-        ratings_over_time.length
+        scoped_ratings.length
       else
-        ratings_over_time.where(score: score).length
+        get_score_count(score, scoped_ratings)
       end
     else
       0
     end
+  end
+
+  def get_score_count(score, ratings)
+    count = 0
+    ratings.each do |rating|
+      count += 1 if rating.score == score
+    end
+    count
   end
 
   def get_score(score, start_time, end_time)

--- a/app/models/checkpoint.rb
+++ b/app/models/checkpoint.rb
@@ -4,21 +4,13 @@ class Checkpoint < ActiveRecord::Base
 
   validates  :expectation, :success_criteria, presence: true
 
-  def overall_score
-    if self.ratings.any?
-      self.ratings.sum(:score) * 50 / self.ratings.size
-    else
-      0
-    end
-  end
-
   def ratings_count(start_time, end_time, score="all")
     if self.ratings.any?
-      ratings_over_time = self.ratings.where({ created_at: start_time..end_time })
+      ratings_over_time = self.ratings.where({ created_at: start_time..end_time }).group(:student_id)
       if score == "all"
-        ratings_over_time.count
+        ratings_over_time.length
       else
-        ratings_over_time.where(score: score).count
+        ratings_over_time.where(score: score).length
       end
     else
       0

--- a/test/fixtures/checkpoints.yml
+++ b/test/fixtures/checkpoints.yml
@@ -6,6 +6,11 @@ one:
   track: one
 
 two:
-  expectation: MyString
-  success_criteria: MyString
-  track_id:
+  expectation: Can build a thing
+  success_criteria: something
+  track: one
+
+noratings:
+  expectation: Can build a thing
+  success_criteria: something
+  track: one

--- a/test/fixtures/ratings.yml
+++ b/test/fixtures/ratings.yml
@@ -3,7 +3,19 @@
 one:
   score: 1
   checkpoint: one
+  student: student1
 
 two:
   score: 1
   checkpoint: one
+  student: student2
+
+three:
+  score: 1
+  checkpoint: two
+  student: student1
+
+four:
+  score: 1
+  checkpoint: two
+  student: student1

--- a/test/fixtures/ratings.yml
+++ b/test/fixtures/ratings.yml
@@ -9,13 +9,3 @@ two:
   score: 1
   checkpoint: one
   student: student2
-
-three:
-  score: 1
-  checkpoint: two
-  student: student1
-
-four:
-  score: 1
-  checkpoint: two
-  student: student1

--- a/test/integration/student_view_test.rb
+++ b/test/integration/student_view_test.rb
@@ -3,15 +3,21 @@ require 'test_helper'
 class StudentViewTest < Capybara::Rails::TestCase
 
   test "a student can rate checkpoints" do
-    login_as(users(:student))
+    student = users(:student)
+    login_as(student)
+    classroom = student.classrooms.first
 
-    click_link "Ahmed's Intro To Curry"
-    click_link "First Track"
+    click_link classroom.name
+    track = classroom.tracks.first
+    click_link track.name
 
-    assert page.has_content?("Can build a thing")
+    checkpoint = track.checkpoints.first
+    assert page.has_content?(checkpoint.expectation)
 
-    assert_difference 'Rating.count' do
-      click_button 'Totally Understand'
+    within "#checkpoint#{checkpoint.id}" do
+      assert_difference 'Rating.count' do
+        click_button 'Totally Understand'
+      end
     end
 
     assert_equal users(:student).classrole, Rating.last.student, 'Student is not associated with the rating'

--- a/test/models/checkpoint_test.rb
+++ b/test/models/checkpoint_test.rb
@@ -38,8 +38,24 @@ class CheckpointTest < ActiveSupport::TestCase
   end
 
   test "only one rating per student counts" do
-    # checkpoints(:two) has two ratings by same student
     @checkpoint_two = checkpoints(:two)
-    assert_equal 1, @checkpoint_two.ratings_count(@start_time, @end_time, 1)
+
+    student = students(:student1)
+    first_rating = Rating.new(score: 1)
+    first_rating.student = student
+    first_rating.checkpoint = @checkpoint_two
+    first_rating.save
+
+    second_rating = Rating.new(score: 2)
+    second_rating.student = student
+    second_rating.checkpoint = @checkpoint_two
+    second_rating.save
+
+    @start = first_rating.created_at - 1
+    @end = second_rating.created_at
+
+    assert_equal 0, @checkpoint_two.ratings_count(@start, @end, 1)
+    assert_equal 1, @checkpoint_two.ratings_count(@start, @end, 2)
+    assert_equal 1, @checkpoint_two.ratings_count(@start, @end)
   end
 end

--- a/test/models/checkpoint_test.rb
+++ b/test/models/checkpoint_test.rb
@@ -3,9 +3,9 @@ require 'test_helper'
 class CheckpointTest < ActiveSupport::TestCase
 
   before do
-    # fixture has two ratings each with a score of 1
+    # checkpoints(:one) has two unique ratings (score of 1)
     @checkpoint = checkpoints(:one)
-    @checkpoint_no_ratings = checkpoints(:two)
+    @checkpoint_no_ratings = checkpoints(:noratings)
     @start_time = @checkpoint.ratings.first.created_at - 1
     @end_time = @checkpoint.ratings.last.created_at
   end
@@ -18,11 +18,6 @@ class CheckpointTest < ActiveSupport::TestCase
     checkpoint = Checkpoint.new(success_criteria: 'something else')
     checkpoint.valid?
     assert checkpoint.errors[:expectation].any?
-  end
-
-  test "overall score" do
-    assert_equal 50, @checkpoint.overall_score
-    assert_equal 0, @checkpoint_no_ratings.overall_score
   end
 
   test "ratings count" do
@@ -40,5 +35,11 @@ class CheckpointTest < ActiveSupport::TestCase
     assert_equal 0, @checkpoint.get_score(2, @start_time, @end_time)
 
     assert_equal 0, @checkpoint_no_ratings.get_score(2, @start_time, @end_time)
+  end
+
+  test "only one rating per student counts" do
+    # checkpoints(:two) has two ratings by same student
+    @checkpoint_two = checkpoints(:two)
+    assert_equal 1, @checkpoint_two.ratings_count(@start_time, @end_time, 1)
   end
 end


### PR DESCRIPTION
This addresses "Teachers should only see data for student's latest rating".

[finish #58748160]
