### PR TITLE
Realtimebars

### DIFF
--- a/app/controllers/analytics_controller.rb
+++ b/app/controllers/analytics_controller.rb
@@ -5,7 +5,7 @@ class AnalyticsController < ApplicationController
 
   def show
     @track = @classroom.tracks.find(params[:track_id])
-    @phase = Phase.new(@track, params[:phase_text] || "Realtime")
+    @phase = Phase.new(@track, params[:phase_state] || "Realtime")
   end
 
 end

--- a/app/controllers/analytics_controller.rb
+++ b/app/controllers/analytics_controller.rb
@@ -5,7 +5,7 @@ class AnalyticsController < ApplicationController
 
   def show
     @track = @classroom.tracks.find(params[:track_id])
-    @phase = Phase.new(@track, params[:phase_text] || "All")
+    @phase = Phase.new(@track, params[:phase_text] || "Realtime")
   end
 
 end

--- a/app/services/phase.rb
+++ b/app/services/phase.rb
@@ -1,11 +1,11 @@
 class Phase
-  attr_reader :phase_text
+  attr_reader :state
   PHASES = ['Realtime','Before','During','After']
 
-  def initialize(track, phase_text)
+  def initialize(track, state)
     @track = track
-    @phase_text = phase_text
-    unless PHASES.include?(@phase_text)
+    @state = state
+    unless PHASES.include?(@state)
       raise ArgumentError.new("Invalid phase")
     end
     @start_of_everything = track.created_at
@@ -13,9 +13,9 @@ class Phase
   end
 
   def start_time
-    if @phase_text == 'During'
+    if @state == 'During'
       return @track.start_time
-    elsif @phase_text == 'After'
+    elsif @state == 'After'
       return @track.end_time
     else
       return @start_of_everything
@@ -23,9 +23,9 @@ class Phase
   end
 
   def end_time
-    if @phase_text == 'Before'
+    if @state == 'Before'
       return @track.start_time
-    elsif @phase_text == 'During'
+    elsif @state == 'During'
       return @track.end_time
     else
       return @end_of_everything

--- a/app/services/phase.rb
+++ b/app/services/phase.rb
@@ -1,6 +1,6 @@
 class Phase
   attr_reader :phase_text
-  PHASES = ['All','Before','During','After']
+  PHASES = ['Realtime','Before','During','After']
 
   def initialize(track, phase_text)
     @track = track

--- a/app/views/analytics/_phasing.html.erb
+++ b/app/views/analytics/_phasing.html.erb
@@ -1,5 +1,5 @@
 <p><%= display_start_end_times(@track) %></p>
 <%= form_tag classroom_track_analytics_path(@classroom, @track), method: "get" do  %>
-  <%= select_tag :phase_text, options_for_select(Phase::PHASES, @phase.phase_text) %>
-  <%= submit_tag 'Choose phase', class: 'add-phase btn'%>
+  <%= select_tag :phase_state, options_for_select(Phase::PHASES, @phase.state) %>
+  <%= submit_tag 'Choose phase', name: nil, class: 'add-phase btn'%>
 <% end %>

--- a/app/views/analytics/show.html.erb
+++ b/app/views/analytics/show.html.erb
@@ -1,4 +1,4 @@
-<%= subscribe_to "/track/#{@track.id}/ratings" %>
+<%= subscribe_to "/track/#{@track.id}/ratings" if @phase.state == 'Realtime' %>
 
 <div id="page-head">
   <h2 class="page-header">Analytics > <%= @track.name %></h2>

--- a/test/helpers/analytics_helper_test.rb
+++ b/test/helpers/analytics_helper_test.rb
@@ -14,7 +14,7 @@ class AnalyticsHelperTest < ActionView::TestCase
     Time.zone.expects(:now).returns(date_in_future)
     @checkpoint.track.created_at = date_in_past
 
-    @phase = Phase.new(@checkpoint.track,"All")
+    @phase = Phase.new(@checkpoint.track,"Realtime")
   end
 
   test "checkpoint with two ratings count" do

--- a/test/models/checkpoint_test.rb
+++ b/test/models/checkpoint_test.rb
@@ -12,7 +12,7 @@ class CheckpointTest < ActiveSupport::TestCase
     Time.zone.expects(:now).returns(date_in_future)
     @checkpoint.track.created_at = date_in_past
 
-    @phase = Phase.new(@checkpoint.track,"All")
+    @phase = Phase.new(@checkpoint.track,"Realtime")
   end
 
   test "validate presence of both attributes" do

--- a/test/models/services/phase_test.rb
+++ b/test/models/services/phase_test.rb
@@ -12,7 +12,7 @@ class PhaseTest < ActiveSupport::TestCase
     @test_phase_before = Phase.new(@test_track,"Before")
     @test_phase_during = Phase.new(@test_track,"During")
     @test_phase_after = Phase.new(@test_track,"After")
-    @test_phase_all = Phase.new(@test_track,"All")
+    @test_phase_all = Phase.new(@test_track,"Realtime")
   end
 
   def test_bad_phase_error
@@ -48,7 +48,7 @@ class PhaseTest < ActiveSupport::TestCase
   end
 
   def test_phase_scopes_ratings
-    phase = Phase.new(tracks(:one), "All")
+    phase = Phase.new(tracks(:one), "Realtime")
     assert_equal 2, phase.ratings(checkpoints(:one)).size
   end
 


### PR DESCRIPTION
This branch turns off the realtime updating of the bars for the phases(before, during, and after). On master right now if you are on one of the phases and a student votes then the bar will update to include all data... very unintuitive behaviour.

So from now on data will only update for the "realtime" phase and the other phases will update with a regular browser update. This seems like more intuitive behaviour. 
