### PR TITLE
add subnav for account link

### DIFF
--- a/app/assets/javascripts/domready.js.coffee
+++ b/app/assets/javascripts/domready.js.coffee
@@ -34,3 +34,8 @@ $ ->
   $('.collapse-toggle').on 'click', ->
     $('body').toggleClass('nav-open')
     CurriUiOptions.update()
+
+  # Subnav Toggle
+  $('.subnav-toggle').on 'click', ->
+    $('div.main').toggleClass('subnav-open')
+    $('ul.subnav').toggleClass('show')

--- a/app/assets/javascripts/domready.js.coffee
+++ b/app/assets/javascripts/domready.js.coffee
@@ -34,8 +34,6 @@ $ ->
   $('.collapse-toggle').on 'click', ->
     $('body').toggleClass('nav-open')
     CurriUiOptions.update()
-
-  $('.collapse-toggle').on 'click', ->
     $('.main').removeClass('subnav-open')
     $('.subnav').removeClass('show')
 

--- a/app/assets/javascripts/domready.js.coffee
+++ b/app/assets/javascripts/domready.js.coffee
@@ -37,5 +37,5 @@ $ ->
 
   # Subnav Toggle
   $('.subnav-toggle').on 'click', ->
-    $('div.main').toggleClass('subnav-open')
-    $('ul.subnav').toggleClass('show')
+    $('.main').toggleClass('subnav-open')
+    $('.subnav').toggleClass('show')

--- a/app/assets/javascripts/domready.js.coffee
+++ b/app/assets/javascripts/domready.js.coffee
@@ -35,6 +35,10 @@ $ ->
     $('body').toggleClass('nav-open')
     CurriUiOptions.update()
 
+  $('.collapse-toggle').on 'click', ->
+    $('.main').removeClass('subnav-open')
+    $('.subnav').removeClass('show')
+
   # Subnav Toggle
   $('.subnav-toggle').on 'click', ->
     $('.main').toggleClass('subnav-open')

--- a/app/assets/stylesheets/base.css.scss
+++ b/app/assets/stylesheets/base.css.scss
@@ -43,22 +43,37 @@ a {
   }
 }
 
-h1 {
+h1,
+h2,
+h3,
+h4,
+.h1,
+.h2,
+.h3,
+.h4 {
+  font-weight: 700;
+}
+
+h1, 
+.h1 {
   font-size: 2rem;
   margin: 1.5rem 0 0.9rem;
 }
 
-h2 {
+h2, 
+.h2 {
   font-size: 1.8rem;
   margin: 1.3rem 0 0.75rem;
 }
 
-h3 {
+h3,
+.h3 {
   font-size: 1.5rem;
   margin: 1rem 0 0.6rem;
 }
 
-h4 {
+h4,
+.h4 {
   font-size: 1.2rem;
   margin: 0.7rem 0 0.5rem;
 }

--- a/app/assets/stylesheets/globals/_mixins.css.scss
+++ b/app/assets/stylesheets/globals/_mixins.css.scss
@@ -1,4 +1,3 @@
-//Mixins
 
 @mixin all-transition {
   -webkit-transition: all 0.3s ease-in-out;
@@ -12,6 +11,14 @@
   -moz-border-radius: $border-radius;
   -o-border-radius: $border-radius;
   border-radius: $border-radius;
+}
+
+@mixin translate($x-val, $y-val) {
+  -webkit-transform: translate($x-val, $y-val);
+  -moz-transform: translate($x-val, $y-val);
+  -ms-transform: translate($x-val, $y-val);
+  -o-transform: translate($x-val, $y-val);
+  transform: translate($x-val, $y-val);
 }
 
 @mixin media-query($media-query) {

--- a/app/assets/stylesheets/layout.css.scss
+++ b/app/assets/stylesheets/layout.css.scss
@@ -156,7 +156,7 @@
   top: 0;
   left: 0;
   bottom: 0;
-  background: #415463;
+  background: $color-main;
   z-index: 100;
 }
 
@@ -185,12 +185,13 @@ body.nav-open .fixed-nav {
   display: none;
 }
 
-.nav-links {
-  color: lighten($color-main, 40%);
+.nav-links, .subnav-links {
   display: block;
   padding: 15px 20px;
   line-height: 1;
-  cursor: pointer;
+}
+.nav-links {
+  color: lighten($color-main, 40%);
   overflow: hidden; // tooltips
   position: relative; // tooltips
   &:hover,
@@ -368,11 +369,19 @@ body.nav-open .nav-label {
   padding: 0 20px 20px 30px;
   background: #FFF;
   // overflow: hidden; // for floated children
+  -webkit-transition: all 0.3s ease;
+  &.subnav-open {
+    @include translate(130px, 0);
+  }
 }
 
 body.nav-open .main {
   min-width: 480px;
   margin-left: 170px;
+}
+
+body.nav-open .main.subnav-open {
+  @include translate(130px, 0);
 }
 
 .page-header {
@@ -416,6 +425,67 @@ a:hover .nav-burger {
   display: block;
 }
 
+//subnav
+
+.subnav {
+  display: none;
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  right: auto;
+  width: 130px;
+  left: 70px;
+  background: lighten($color-main, 30%);
+  border-right: 1px solid lighten($color-main, 25%);
+  .bottom-nav {
+    margin-bottom: 10px;
+  }
+}
+
+body.nav-open .subnav {
+  left: 170px;
+}
+
+.account-id-header {
+  font-size: 14px;
+  background: $color-main;
+  color: #fff;
+  padding: 5px 20px;
+}
+
+.account-id {
+  color: lighten($color-main, 65%);
+  background: lighten($color-main, 10%);
+  margin-bottom: 10px;
+}
+
+.user-type {
+  display: block;
+}
+
+.user-name {
+  -webkit-font-smoothing: antialiased;
+  font-size: 18px;
+  font-weight: 700;
+  margin-bottom: 5px;
+  margin-top: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.user-role {
+  font-size: 13px;
+}
+
+a.subnav-links {
+  color: $color-main;
+  font-size: 15px;
+  &:hover,
+  &:focus {
+    color: lighten($color-main, 65%);
+  }
+}
+
 // Grid
 
 .grid {
@@ -432,6 +502,10 @@ a:hover .nav-burger {
 
 .pull-right {
   float: right;
+}
+
+.show {
+  display: block;
 }
 
 .narrow, .wide, .whole {

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,7 +1,7 @@
 module ApplicationHelper
 
   def link_to_selected(*arg, &block)
-    if current_page?(arg[0]) || at_track?(arg[0]) || at_classroom?(arg[0])
+    if current_page?(arg[0]) || at_track?(arg[0]) || at_classroom?(arg[0] || at_profile?(arg[0]))
       options = arg.extract_options!
       options[:class] += ' selected'
       arg << options

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,7 +1,7 @@
 module ApplicationHelper
 
   def link_to_selected(*arg, &block)
-    if current_page?(arg[0]) || at_track?(arg[0]) || at_classroom?(arg[0] || at_profile?(arg[0]))
+    if current_page?(arg[0]) || at_track?(arg[0]) || at_classroom?(arg[0]) || at_account?(arg[0])
       options = arg.extract_options!
       options[:class] += ' selected'
       arg << options
@@ -16,6 +16,10 @@ module ApplicationHelper
 
   def at_track?(path)
     path.match(/tracks$/) && (params[:controller] == 'tracks' || params[:controller] == 'checkpoints')
+  end
+
+  def at_account?(path)
+    path.match(/#/) && params[:controller] == 'users'
   end
 
   def current_page_header

--- a/app/views/shared/_logged_in_nav.html.erb
+++ b/app/views/shared/_logged_in_nav.html.erb
@@ -22,21 +22,12 @@
 <% end %>
 
 <div class="bottom-nav">
-  <!-- move all account links into a secondary menu visible on hover -->
-  
-  <!-- <li>
-    <%= link_to_selected edit_profile_path, class: "nav-links", id: 'account' do %>
-      <span class="nav-icon nav-account"></span>
-      <span class="nav-label">Account</span>
-    <% end %>
-  </li> -->
   <li>
     <a href='#' class="nav-links subnav-toggle">
       <span class="nav-icon nav-account"></span>
       <span class="nav-label">Account</span>
     </a>
   </li>
-  <!-- <li class="hide-role"><span> <%= "Role: #{current_user.classrole_type}; #{current_user.email}" %> </span></li> -->
   </li>
   <li>
     <a href='#' class="nav-links collapse-toggle">

--- a/app/views/shared/_logged_in_nav.html.erb
+++ b/app/views/shared/_logged_in_nav.html.erb
@@ -23,17 +23,23 @@
 
 <div class="bottom-nav">
   <!-- move all account links into a secondary menu visible on hover -->
-  <li><%= link_to 'Log Out', logout_path, method: :delete, id: 'logout-link' %></li>
-  <li>
+  
+  <!-- <li>
     <%= link_to_selected edit_profile_path, class: "nav-links", id: 'account' do %>
       <span class="nav-icon nav-account"></span>
       <span class="nav-label">Account</span>
     <% end %>
+  </li> -->
+  <li>
+    <a href='#' class="nav-links subnav-toggle">
+      <span class="nav-icon nav-account"></span>
+      <span class="nav-label">Account</span>
+    </a>
   </li>
   <!-- <li class="hide-role"><span> <%= "Role: #{current_user.classrole_type}; #{current_user.email}" %> </span></li> -->
   </li>
   <li>
-    <a class="nav-links collapse-toggle">
+    <a href='#' class="nav-links collapse-toggle">
       <span class="nav-icon nav-size"></span>
       <span class="nav-label nav-label-hide">Collapse</span>
     </a>

--- a/app/views/shared/_logged_in_nav.html.erb
+++ b/app/views/shared/_logged_in_nav.html.erb
@@ -23,13 +23,13 @@
 
 <div class="bottom-nav">
   <li>
-    <a href='#' class="nav-links subnav-toggle">
+    <a href='#' class="nav-links subnav-toggle ">
       <span class="nav-icon nav-account"></span>
       <span class="nav-label">Account</span>
     </a>
   </li>
   </li>
-  <li>
+  <li class="expand-collapse show-desktop">
     <a href='#' class="nav-links collapse-toggle">
       <span class="nav-icon nav-size"></span>
       <span class="nav-label nav-label-hide">Collapse</span>

--- a/app/views/shared/_logged_in_nav.html.erb
+++ b/app/views/shared/_logged_in_nav.html.erb
@@ -23,10 +23,10 @@
 
 <div class="bottom-nav">
   <li>
-    <a href='#' class="nav-links subnav-toggle ">
+    <%= link_to_selected '#', class: 'nav-links subnav-toggle' do %>
       <span class="nav-icon nav-account"></span>
       <span class="nav-label">Account</span>
-    </a>
+    <% end %>
   </li>
   </li>
   <li class="expand-collapse show-desktop">

--- a/app/views/shared/_nav.html.erb
+++ b/app/views/shared/_nav.html.erb
@@ -1,5 +1,4 @@
 <div class="fixed-nav show-desktop">
-  <!-- <div id="logo"><a href="/"><%= image_tag("logo2.svg") %></a></div> -->
   <ul>
     <% if current_user %>
       <%= render 'shared/logged_in_nav' %>

--- a/app/views/shared/_nav.html.erb
+++ b/app/views/shared/_nav.html.erb
@@ -7,4 +7,9 @@
       <%= render 'shared/logged_out_nav' %>
     <% end %>
   </ul>
+  <ul class="subnav">
+    <% if current_user %>
+      <%= render 'shared/subnav' %>
+    <% end %>
+  </ul>
 </div>

--- a/app/views/shared/_subnav.html.erb
+++ b/app/views/shared/_subnav.html.erb
@@ -5,7 +5,7 @@
       <span class="user-type user-role"><%= current_user.classrole_type %></span>
     </li>
     <li>
-      <%= link_to_selected 'Edit Profile', edit_profile_path, class: "subnav-links", id: 'account' %>
+      <%= link_to 'Edit Profile', edit_profile_path, class: "subnav-links", id: 'account' %>
     </li>
     <li>
       <%= link_to 'Log Out', logout_path, method: :delete, class: "subnav-links", id: 'logout-link' %>

--- a/app/views/shared/_subnav.html.erb
+++ b/app/views/shared/_subnav.html.erb
@@ -1,0 +1,13 @@
+<div class="bottom-nav">
+  <li class="account-id-header">Account</li>
+    <li class="subnav-links account-id">
+      <span class="user-type user-name"><%= current_user.first_name %></span>
+      <span class="user-type user-role"><%= current_user.classrole_type %></span>
+    </li>
+    <li>
+      <%= link_to_selected 'Edit Profile', edit_profile_path, class: "subnav-links", id: 'account' %>
+    </li>
+    <li>
+      <%= link_to 'Log Out', logout_path, method: :delete, class: "subnav-links", id: 'logout-link' %>
+    </li>
+</div>


### PR DESCRIPTION
This is the additional subnav I wanted to add:
- On clicking the account link, the subnav slides out.
- User name (first only) and user role (student/teacher) shows up to ID the account. Long first names will be cut off and show an ellipsis.
- Creating separate icons for student/teacher isn't worth it at this point.
- Edit profile and Logout links also present. Later, we can add other account related links here.
##### Issues:
- When you are on the edit profile view, the account link is not getting the `.selected` class. I tried to make it happen through the `application_helper.rb` but failed miserably.
- In mobile view, when the account link is clicked to open the subnav, things work fine if you select the edit profile or any of the other main nav links (classrooms/tracks/analytics). However, if you tap the collapse link or the burger icon (both have the `.toggle-collapse` class), the `.main` keeps the `.subnav-open` instead of removing it. I can hide the collapse link on mobile but that will still leave the burger icon. 
