### PR TITLE
Publishtracks

### DIFF
--- a/app/controllers/tracks_controller.rb
+++ b/app/controllers/tracks_controller.rb
@@ -5,7 +5,11 @@ class TracksController < ApplicationController
   before_action :get_track, only: [:show, :edit, :update, :destroy]
 
   def index
-    @tracks = @classroom.tracks.includes(:checkpoints)
+    if @current_user.teacher?
+      @tracks = @classroom.tracks.includes(:checkpoints)
+    else
+      @tracks = @classroom.tracks.published.includes(:checkpoints)
+    end
   end
 
   def show
@@ -44,7 +48,7 @@ class TracksController < ApplicationController
 
   private
   def track_params
-    params.require(:track).permit(:name)
+    params.require(:track).permit(:name, :published)
   end
 
   def get_track

--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -4,6 +4,7 @@ class Track < ActiveRecord::Base
   validates :name, presence: true
 
   default_scope { order(id: :asc) }
+  scope :published, -> { where(published: true) }
 
   def phasing?
     start_time && end_time

--- a/app/views/classrooms/_classroom.html.erb
+++ b/app/views/classrooms/_classroom.html.erb
@@ -8,7 +8,11 @@
     <%= "Student".pluralize(classroom.students.size) %>
   </p>
   <h2>
-    <%= classroom.tracks.size %> <%= "Track".pluralize(classroom.tracks.size) %>
+    <% if current_user.teacher? %>
+      <%= classroom.tracks.size %> <%= "Track".pluralize(classroom.tracks.size) %>
+    <% else %>
+      <%= classroom.tracks.published.size %> <%= "Track".pluralize(classroom.tracks.published.size) %>
+    <% end %>
   </h2>
   </div>
 <% end %>

--- a/app/views/tracks/_form.html.erb
+++ b/app/views/tracks/_form.html.erb
@@ -15,6 +15,8 @@
     <%= f.text_field :end_date, value: nice_date_format(@track, :end_time), placeholder: Time.zone.now.strftime("%Y-%m-%d"), class: "form-input form-input-inline"  %>
     <%= f.text_field :end_time, value: nice_time_format(@track, :end_time), placeholder: Time.zone.now.strftime("%l:%M%P"), class: "form-input form-input-inline"  %>
   </span>
+
+  <%= f.label :published %> <%= f.check_box :published%>
   <div>
     <%= f.submit class: "add-track btn" %>
   </div>

--- a/app/views/tracks/show.html.erb
+++ b/app/views/tracks/show.html.erb
@@ -1,5 +1,7 @@
 <div id="page-head">
-  <h2 class="page-header"><%= @classroom.name %> > <%= @track.name %></h2>
+  <h2 class="page-header"><%= @classroom.name %> > <%= @track.name %>
+  <%= ' [Unpublished]' unless @track.published %>
+  </h2>
 
   <!-- Teacher Controls -->
   <% if current_user.teacher? %>

--- a/db/migrate/20140109173958_add_published_to_tracks.rb
+++ b/db/migrate/20140109173958_add_published_to_tracks.rb
@@ -1,0 +1,9 @@
+class AddPublishedToTracks < ActiveRecord::Migration
+  def change
+    add_column :tracks, :published, :boolean, default: false
+    Track.all.each do |track|
+      track.published = true
+      track.save
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140105194609) do
+ActiveRecord::Schema.define(version: 20140109173958) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -78,6 +78,7 @@ ActiveRecord::Schema.define(version: 20140105194609) do
     t.integer  "classroom_id"
     t.datetime "start_time"
     t.datetime "end_time"
+    t.boolean  "published",    default: false
   end
 
   add_index "tracks", ["classroom_id"], name: "index_tracks_on_classroom_id", using: :btree

--- a/test/controllers/tracks_controller_test.rb
+++ b/test/controllers/tracks_controller_test.rb
@@ -12,6 +12,22 @@ class TracksControllerTest < ActionController::TestCase
     assert :success
   end
 
+  test "teacher should see unpublished tracks" do
+    get :index, classroom_id: classrooms(:one)
+    tracks = assigns(:tracks)
+    assert_equal 2, tracks.length
+    assert tracks.include?(tracks(:two))
+  end
+
+  test "student should not see unpublished tracks" do
+    session[:user_id] = users(:student1).id
+    get :index, classroom_id: classrooms(:one)
+
+    tracks = assigns(:tracks)
+    assert_equal 1, tracks.length
+    assert_equal false, tracks.include?(tracks(:two))
+  end
+
   test "show single track" do
     get :show, classroom_id: classrooms(:one), id: tracks(:one)
     assert assigns(:track)
@@ -62,6 +78,18 @@ class TracksControllerTest < ActionController::TestCase
     patch :update, classroom_id: classrooms(:one), id: tracks(:one), track: {name: nil }
 
     assert_template :edit
+  end
+
+  test "should be able to unpublish a track" do
+    patch :update, classroom_id: classrooms(:one), id: tracks(:one), track: {published: false }
+
+    assert_equal false, tracks(:one).reload.published
+  end
+
+  test "should be able to publish a track" do
+    patch :update, classroom_id: classrooms(:one), id: tracks(:two), track: {published: true }
+
+    assert tracks(:two).reload.published
   end
 
   test "should correctly update time/date attributes" do

--- a/test/features/teacher_tracks_test.rb
+++ b/test/features/teacher_tracks_test.rb
@@ -26,6 +26,26 @@ class TeacherTracksTest < Capybara::Rails::TestCase
     assert page.has_content?('New track name')
   end
 
+  test "a teacher can unpublish a published track" do
+    click_link @track.name
+    click_link 'manage-track'
+
+    uncheck :track_published
+    click_button 'Update Track'
+
+    assert page.has_content?('[Unpublished]'), 'The unpublished track was not labelled'
+  end
+
+  test "a teacher can publish an unpublished track" do
+    click_link tracks(:two).name
+    click_link 'manage-track'
+
+    check :track_published
+    click_button 'Update Track'
+
+    assert !page.has_content?('[Unpublished]'), 'The published track was labelled with [Unpublished]'
+  end
+
   test "a teacher can edit a track" do
     click_link @track.name
     click_link 'manage-track'

--- a/test/fixtures/tracks.yml
+++ b/test/fixtures/tracks.yml
@@ -5,6 +5,9 @@ one:
   classroom: one
   start_time: <%= Time.zone.parse("2012-10-1 6am") %>
   end_time: <%= Time.zone.parse("2012-10-3 6am") %>
+  published: true
 
 two:
-  name: MyString
+  name: Unpublished Track
+  classroom: one
+  published: false


### PR DESCRIPTION
This is implementing the feature that we talked about at some point -- tracks are unpublished by default with the option of being published. That way teachers can work without students seeing the result right away.
