### PR TITLE
Multiple teachers

### DIFF
--- a/app/assets/stylesheets/modules/classrooms.css.scss
+++ b/app/assets/stylesheets/modules/classrooms.css.scss
@@ -51,8 +51,8 @@ $bluegrey-v-lt: #F8FAFC;
   position: relative;
 }
 
-.pending-inv, 
-.unpublished-tracks, 
+.pending-inv,
+.unpublished-tracks,
 .no-pending-inv,
 .all-published {
   margin: -6px 0 0 43px;
@@ -60,7 +60,7 @@ $bluegrey-v-lt: #F8FAFC;
   font-weight: 700;
 }
 .pending-inv,
-.unpublished-tracks {
+.unpublished-tracks, .teacher-token {
   color: $color-warning;
 }
 
@@ -90,7 +90,7 @@ $bluegrey-v-lt: #F8FAFC;
   background-position: -24px -180px;
 }
 
-.student-num, 
+.student-num,
 .track-num {
   font-weight: 700;
   margin-left: 43px;

--- a/app/controllers/classrooms_controller.rb
+++ b/app/controllers/classrooms_controller.rb
@@ -1,6 +1,6 @@
 class ClassroomsController < ApplicationController
 
-  before_action :authorize_teacher, except: [:index, :show]
+  before_action :authorize_teacher, except: [:index, :show, :destroy]
   before_action :get_classroom, only: [:edit, :update, :destroy]
 
   def index
@@ -45,8 +45,8 @@ class ClassroomsController < ApplicationController
   end
 
   def destroy
-    @classroom.destroy
-    redirect_to classrooms_path, notice: "Classroom has been deleted."
+    @current_user.classrooms.delete(@classroom)
+    redirect_to classrooms_path, notice: "You have left the classroom."
   end
 
   private

--- a/app/controllers/classrooms_controller.rb
+++ b/app/controllers/classrooms_controller.rb
@@ -20,6 +20,19 @@ class ClassroomsController < ApplicationController
     end
   end
 
+  def join
+    classroom = Classroom.find_by(teacher_token: params[:teacher_token])
+
+    if classroom
+      @current_user.classrooms << classroom
+      redirect_to classrooms_path, notice: "You have joined '#{classroom.name}' as a teacher."
+    else
+      @classroom = Classroom.new
+      flash.now.alert = 'Invalid Token'
+      render :new
+    end
+  end
+
   def edit
   end
 

--- a/app/controllers/classrooms_controller.rb
+++ b/app/controllers/classrooms_controller.rb
@@ -46,6 +46,9 @@ class ClassroomsController < ApplicationController
 
   def destroy
     @current_user.classrooms.delete(@classroom)
+    if @classroom.teachers.empty? && @classroom.students.empty?
+      @classroom.destroy
+    end
     redirect_to classrooms_path, notice: "You have left the classroom."
   end
 

--- a/app/models/classroom.rb
+++ b/app/models/classroom.rb
@@ -4,7 +4,8 @@ class Classroom < ActiveRecord::Base
   has_many :invitations
   has_many :students, through: :invitations
 
-  belongs_to :teacher
+  has_many :classroom_teachers
+  has_many :teachers, through: :classroom_teachers
   validates :name, presence: true
 
   default_scope { order(id: :asc) }

--- a/app/models/classroom.rb
+++ b/app/models/classroom.rb
@@ -9,9 +9,16 @@ class Classroom < ActiveRecord::Base
   validates :name, presence: true
 
   default_scope { order(id: :asc) }
+  before_create :generate_token
 
   def requesters
     invitations.help_needed
+  end
+
+  def generate_token
+    begin
+      self.teacher_token = SecureRandom.urlsafe_base64(6)
+    end while Classroom.exists?(teacher_token: self.teacher_token)
   end
 
 end

--- a/app/models/classroom_teacher.rb
+++ b/app/models/classroom_teacher.rb
@@ -1,0 +1,4 @@
+class ClassroomTeacher < ActiveRecord::Base
+  belongs_to :classroom
+  belongs_to :teacher
+end

--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -15,8 +15,8 @@ class Teacher < ActiveRecord::Base
 
     default_classroom = self.classrooms.find_by(name: "Sample Classroom")
 
-    js_track = default_classroom.tracks.create(name: "Beginner JavaScript")
-    jq_track = default_classroom.tracks.create(name: "Beginner jQuery")
+    js_track = default_classroom.tracks.create(name: "Beginner JavaScript", published: true)
+    jq_track = default_classroom.tracks.create(name: "Beginner jQuery", published: false)
 
     js_track.checkpoints.create([
       {expectation: "JavaScript & its uses", success_criteria: "JavaScript is a programming language used mainly for interactivity on web browsers."},

--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -1,6 +1,7 @@
 class Teacher < ActiveRecord::Base
   has_one :user, as: :classrole, dependent: :destroy
-  has_many :classrooms
+  has_many :classroom_teachers
+  has_many :classrooms, through: :classroom_teachers
 
   delegate :email, to: :user
   delegate :first_name, to: :user

--- a/app/views/classrooms/_form.html.erb
+++ b/app/views/classrooms/_form.html.erb
@@ -1,13 +1,13 @@
 <%= form_for @classroom do |f| %>
   <%= f.error_messages %>
   <h3>
-    <%= f.label :name, 'Classroom Name' %>
+    <%= f.label :name, 'New Classroom Name' %>
   </h3>
   <span>
     <%= f.text_field :name, placeholder: "Enter classroom name", class: "form-input" %>
   </span>
   <span>
-    <%= f.text_area :description, maxlength: "65", placeholder: "Enter classroom description", class: "form-input" %>
+    <%= f.text_area :description, maxlength: "65", placeholder: "Enter classroom description (optional; max 65 chars)", class: "form-input" %>
   </span>
   <div>
     <%= f.submit class: "add-classroom btn" %>

--- a/app/views/classrooms/edit.html.erb
+++ b/app/views/classrooms/edit.html.erb
@@ -3,6 +3,8 @@
     <h5 class="subtitle"><%= @classroom.name %></h5>
   <%= render 'form' %>
 
+  <p>To invite additional <span class='teacher-token'>teachers</span> to the classroom please use the following token <span class='teacher-token'><%= @classroom.teacher_token %></span></p>
+
   <%= link_to 'Delete Classroom', @classroom, method: :delete, data: {confirm: "Are you sure you want to delete the classroom?"}, class: "btn btn-head pull-right", id: 'delete-classroom' %>
   </div>
 </div>

--- a/app/views/classrooms/edit.html.erb
+++ b/app/views/classrooms/edit.html.erb
@@ -3,7 +3,7 @@
     <h5 class="subtitle"><%= @classroom.name %></h5>
   <%= render 'form' %>
 
-  <p>To invite additional <span class='teacher-token'>teachers</span> to the classroom please use the following token <span class='teacher-token'><%= @classroom.teacher_token %></span></p>
+  <p>To invite additional <span class='teacher-token'>teachers</span> to the classroom please give the following token <span class='teacher-token'><%= @classroom.teacher_token %></span></p>
 
   <%= link_to 'Leave Classroom', @classroom, method: :delete, data: {confirm: "Are you sure you want to leave the classroom?"}, class: "btn btn-head pull-right", id: 'delete-classroom' %>
   </div>

--- a/app/views/classrooms/edit.html.erb
+++ b/app/views/classrooms/edit.html.erb
@@ -5,6 +5,6 @@
 
   <p>To invite additional <span class='teacher-token'>teachers</span> to the classroom please use the following token <span class='teacher-token'><%= @classroom.teacher_token %></span></p>
 
-  <%= link_to 'Delete Classroom', @classroom, method: :delete, data: {confirm: "Are you sure you want to delete the classroom?"}, class: "btn btn-head pull-right", id: 'delete-classroom' %>
+  <%= link_to 'Leave Classroom', @classroom, method: :delete, data: {confirm: "Are you sure you want to leave the classroom?"}, class: "btn btn-head pull-right", id: 'delete-classroom' %>
   </div>
 </div>

--- a/app/views/classrooms/index.html.erb
+++ b/app/views/classrooms/index.html.erb
@@ -11,7 +11,7 @@
       <div class="classroom">
         <%= link_to new_classroom_path, class: "classroom-content", id: "add-classroom" do %>
           <div class="add-sign">+</div>
-          <p class="add-text">Add New Classroom</p>
+          <p class="add-text">Add/Join Classroom</p>
         <% end %>
       </div>
     </div>

--- a/app/views/classrooms/new.html.erb
+++ b/app/views/classrooms/new.html.erb
@@ -2,5 +2,13 @@
     <h2>Add Classroom</h2>
     <%= render 'form' %>
   </div>
+
+  <div class="grid-unit wide">
+    <h3>Join Classroom</h3>
+    <%= form_tag join_classrooms_path, method: :post do %>
+      <%= text_field_tag :teacher_token, nil,placeholder: "Enter classroom token", class: "form-input" %>
+      <%= submit_tag 'Join Classroom', class: "btn" %>
+    <% end %>
+  </div>
 </div>
 <% provide(:title, 'Add Classroom') %>

--- a/app/views/classrooms/new.html.erb
+++ b/app/views/classrooms/new.html.erb
@@ -1,10 +1,10 @@
   <div class="grid-unit wide">
-    <h2>Add Classroom</h2>
+    <h2>Add/Join Classroom</h2>
     <%= render 'form' %>
   </div>
 
   <div class="grid-unit wide">
-    <h3>Join Classroom</h3>
+    <h3>Join Existing Classroom</h3>
     <%= form_tag join_classrooms_path, method: :post do %>
       <%= text_field_tag :teacher_token, nil,placeholder: "Enter classroom token", class: "form-input" %>
       <%= submit_tag 'Join Classroom', class: "btn" %>

--- a/app/views/tracks/_track.html.erb
+++ b/app/views/tracks/_track.html.erb
@@ -1,7 +1,7 @@
 <div class="grid-unit narrow">
   <div class="classroom">
     <%= link_to classroom_track_path(classroom_id: @classroom, id: track), class: "classroom-content" do %>
-      <h4><%=track.name %></h4>
+      <h4><%=track.name %><%= ' [Unpublished]' unless track.published %></h4>
       <% if current_user.student? %>
         <div class="grid-temp">
           <%= render partial: 'shared/progress_bar', locals: { ratings: current_user.classrole.track_ratings(track), total_count: track.checkpoints.length } %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Curri::Application.routes.draw do
   root to: 'classrooms#index'
 
   resources :classrooms, except: [:show] do
+    post 'join', on: :collection
     resources :requesters, only: [:index, :show, :update] do
       patch 'remove', on: :member
     end

--- a/db/migrate/20140117161433_create_classroom_teachers.rb
+++ b/db/migrate/20140117161433_create_classroom_teachers.rb
@@ -1,0 +1,10 @@
+class CreateClassroomTeachers < ActiveRecord::Migration
+  def change
+    create_table :classroom_teachers do |t|
+      t.references :classroom, index: true
+      t.references :teacher, index: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20140117162343_remove_teacher_from_classroom.rb
+++ b/db/migrate/20140117162343_remove_teacher_from_classroom.rb
@@ -1,0 +1,5 @@
+class RemoveTeacherFromClassroom < ActiveRecord::Migration
+  def change
+    remove_column :classrooms, :teacher_id
+  end
+end

--- a/db/migrate/20140117163747_add_teacher_token_to_classroom.rb
+++ b/db/migrate/20140117163747_add_teacher_token_to_classroom.rb
@@ -1,0 +1,5 @@
+class AddTeacherTokenToClassroom < ActiveRecord::Migration
+  def change
+    add_column :classrooms, :teacher_token, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140109173958) do
+ActiveRecord::Schema.define(version: 20140117162343) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -26,16 +26,24 @@ ActiveRecord::Schema.define(version: 20140109173958) do
 
   add_index "checkpoints", ["track_id"], name: "index_checkpoints_on_track_id", using: :btree
 
+  create_table "classroom_teachers", force: true do |t|
+    t.integer  "classroom_id"
+    t.integer  "teacher_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "classroom_teachers", ["classroom_id"], name: "index_classroom_teachers_on_classroom_id", using: :btree
+  add_index "classroom_teachers", ["teacher_id"], name: "index_classroom_teachers_on_teacher_id", using: :btree
+
   create_table "classrooms", force: true do |t|
     t.string   "name"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "teacher_id"
     t.integer  "students_count", default: 0
     t.integer  "tracks_count",   default: 0
+    t.text     "description"
   end
-
-  add_index "classrooms", ["teacher_id"], name: "index_classrooms_on_teacher_id", using: :btree
 
   create_table "invitations", force: true do |t|
     t.integer  "classroom_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140117162343) do
+ActiveRecord::Schema.define(version: 20140117163747) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -42,7 +42,7 @@ ActiveRecord::Schema.define(version: 20140117162343) do
     t.datetime "updated_at"
     t.integer  "students_count", default: 0
     t.integer  "tracks_count",   default: 0
-    t.text     "description"
+    t.string   "teacher_token"
   end
 
   create_table "invitations", force: true do |t|

--- a/test/controllers/classrooms_controller_test.rb
+++ b/test/controllers/classrooms_controller_test.rb
@@ -72,6 +72,13 @@ class ClassroomsControllerTest < ActionController::TestCase
     assert_redirected_to classrooms_path
   end
 
+  test "should remove classroom with no teachers or students" do
+    session[:user_id] = users(:teacher2).id
+    assert_difference 'Classroom.count', -1 do
+      delete :destroy, id: classrooms(:three)
+    end
+  end
+
   test "should add teacher to classroom" do
     assert_equal 1, users(:teacher1).classrooms.size
     post :join, teacher_token: classrooms(:three).teacher_token

--- a/test/controllers/classrooms_controller_test.rb
+++ b/test/controllers/classrooms_controller_test.rb
@@ -52,10 +52,23 @@ class ClassroomsControllerTest < ActionController::TestCase
     assert_template :edit
   end
 
-  test "delete classroom" do
-    assert_difference 'Classroom.count', -1 do
+  test "should remove teacher from classroom without deleting classroom" do
+    assert_difference 'users(:teacher1).classrooms.count', -1 do
       delete :destroy, id: classrooms(:one)
     end
+
+    assert classrooms(:one).reload
+    assert_redirected_to classrooms_path
+  end
+
+  test "should remove student from classroom without deleting classroom" do
+    session[:user_id] = users(:student1).id
+
+    assert_difference 'users(:student1).classrooms.count', -1 do
+      delete :destroy, id: classrooms(:one)
+    end
+
+    assert classrooms(:one).reload
     assert_redirected_to classrooms_path
   end
 

--- a/test/controllers/classrooms_controller_test.rb
+++ b/test/controllers/classrooms_controller_test.rb
@@ -59,4 +59,28 @@ class ClassroomsControllerTest < ActionController::TestCase
     assert_redirected_to classrooms_path
   end
 
+  test "should add teacher to classroom" do
+    assert_equal 1, users(:teacher1).classrooms.size
+    post :join, teacher_token: classrooms(:three).teacher_token
+
+    assert_equal 2, users(:teacher1).classrooms.size
+  end
+
+  test "should give error with wrong token" do
+    post :join, teacher_token: 'bad-token'
+
+    assert 'Invalid Token', flash[:alert]
+    assert_template :new
+  end
+
+  test "should not add student to classroom using token" do
+    assert_equal 1, users(:student1).classrooms.size
+
+    session[:user_id] = users(:student1).id
+    post :join, teacher_token: classrooms(:three).teacher_token
+
+    assert_equal 1, users(:student1).classrooms.size
+    assert 'Only a teacher can do that.', flash[:alert]
+  end
+
 end

--- a/test/features/teacher_classrooms_test.rb
+++ b/test/features/teacher_classrooms_test.rb
@@ -46,4 +46,13 @@ class TeacherClassroomsTest < Capybara::Rails::TestCase
 
     assert !page.has_content?(@classroom.name)
   end
+
+  test "a teacher can join a classroom using token" do
+    click_link "add-classroom"
+
+    fill_in :teacher_token, with: "ELtCtf7o"
+    click_button 'Join Classroom'
+
+    assert page.has_content?('New Classroom with token')
+  end
 end

--- a/test/fixtures/classroom_teachers.yml
+++ b/test/fixtures/classroom_teachers.yml
@@ -1,0 +1,10 @@
+# Read about fixtures at
+# http://api.rubyonrails.org/classes/ActiveRecord/Fixtures.html
+
+one:
+  classroom: one
+  teacher: teacher1
+
+two:
+  classroom: two
+  teacher: teacher2

--- a/test/fixtures/classroom_teachers.yml
+++ b/test/fixtures/classroom_teachers.yml
@@ -8,3 +8,7 @@ one:
 two:
   classroom: two
   teacher: teacher2
+
+three:
+  classroom: three
+  teacher: teacher2

--- a/test/fixtures/classrooms.yml
+++ b/test/fixtures/classrooms.yml
@@ -5,3 +5,7 @@ one:
 
 two:
   name: Paula's Intro To Art
+
+three:
+  name: New Classroom with token
+  teacher_token: ELtCtf7o

--- a/test/fixtures/classrooms.yml
+++ b/test/fixtures/classrooms.yml
@@ -2,8 +2,6 @@
 
 one:
   name: Ahmed's Intro To Curri
-  teacher: teacher1
 
 two:
   name: Paula's Intro To Art
-  teacher: teacher2

--- a/test/models/classroom_teacher_test.rb
+++ b/test/models/classroom_teacher_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ClassroomTeacherTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/services/phase_test.rb
+++ b/test/services/phase_test.rb
@@ -49,30 +49,30 @@ class PhaseTest < ActiveSupport::TestCase
 
   test "phase scopes ratings" do
     phase = Phase.new(tracks(:one), "Realtime")
-    assert_equal 2, phase.ratings(checkpoints(:one)).size
+    assert_equal 2, phase.ratings(checkpoints(:one)).length
   end
 
   test "before phase scopes ratings" do
     @test_track.checkpoints << checkpoints(:one)
-    assert_equal 0, @test_phase_before.ratings(checkpoints(:one)).size
+    assert_equal 0, @test_phase_before.ratings(checkpoints(:one)).length
 
     checkpoints(:one).ratings << Rating.new(score: 1, student: students(:student1), created_at: @beforeDate)
-    assert_equal 1, @test_phase_before.ratings(checkpoints(:one)).size
+    assert_equal 1, @test_phase_before.ratings(checkpoints(:one)).length
   end
 
   test "during phase scopes ratings" do
     @test_track.checkpoints << checkpoints(:one)
-    assert_equal 0, @test_phase_during.ratings(checkpoints(:one)).size
+    assert_equal 0, @test_phase_during.ratings(checkpoints(:one)).length
 
     checkpoints(:one).ratings << Rating.new(score: 1, student: students(:student1), created_at: @duringDate)
-    assert_equal 1, @test_phase_during.ratings(checkpoints(:one)).size
+    assert_equal 1, @test_phase_during.ratings(checkpoints(:one)).length
   end
 
   test "after phase scopes ratings" do
     @test_track.checkpoints << checkpoints(:one)
-    assert_equal 2, @test_phase_after.ratings(checkpoints(:one)).size
+    assert_equal 2, @test_phase_after.ratings(checkpoints(:one)).length
 
     checkpoints(:one).ratings << Rating.new(score: 1, student: students(:student1), created_at: @duringDate)
-    assert_equal 2, @test_phase_after.ratings(checkpoints(:one)).size
+    assert_equal 2, @test_phase_after.ratings(checkpoints(:one)).length
   end
 end


### PR DESCRIPTION
To work with this branch you will need to reset your database because the relationship between teachers and classrooms changes. So:

```
$ rake db:drop
$ rake db:setup
```

How this feature works:
1. When a classroom is created, a unique 8 character long string is created called `teacher_token`.
2. Clicking "add classroom" will give you the option of joining a classroom instead by inputing the token.
3. Invalid token will redirect back to the form and say "Invalid Token" **Issue 1**
4. Valid token will add the teacher with full admin rights.
5. On a classroom's edit page (by clicking "mange classroom") you will see the statement: `To invite additional teachers to the classroom please use the following token p8vHvP_4`. The teacher then passes this token to their colleagues to get them to join.

Issues:
1. The flash notifications are not displayed on the page. The markup is there, the style just needs to be fixed.
