### PR TITLE
style navigation sidebar

### DIFF
--- a/app/assets/javascripts/domready.js.coffee
+++ b/app/assets/javascripts/domready.js.coffee
@@ -64,3 +64,20 @@ $ ->
    $('.choices-toggle').on 'click', (e) ->
       e.preventDefault()
       $(this).closest('li').find('.choices').toggleClass('show')
+
+  # Sidebar mobile select menu
+  $("<select />").appendTo("#sidebar-links")
+  $("<option />", {
+     "selected": "selected",
+     "value"   : "",
+     "text"    : "Go to..."
+  }).appendTo("#sidebar-links select")
+  $('#sidebar-links a').each ->
+    el = $(this)
+    $("<option />", {
+         "value"   : el.attr("href"),
+         "text"    : el.text()
+     }).appendTo("#sidebar-links select")
+
+  $('#sidebar-links select').on 'change', ->
+    window.location = $(this).find("option:selected").val()

--- a/app/assets/stylesheets/layout.css.scss
+++ b/app/assets/stylesheets/layout.css.scss
@@ -80,7 +80,7 @@ body.nav-open .main {
   // display: inline-block; // causes textual whitespace
   float: left;
   padding-left: 20px;
-  margin-bottom: 25px;
+  margin: 0 auto 25px;
 }
 
 .unit-header {

--- a/app/assets/stylesheets/layout.css.scss
+++ b/app/assets/stylesheets/layout.css.scss
@@ -80,7 +80,7 @@ body.nav-open .main {
   // display: inline-block; // causes textual whitespace
   float: left;
   padding-left: 20px;
-  margin: 15px auto 10px;
+  margin-bottom: 25px;
 }
 
 .unit-header {
@@ -173,12 +173,16 @@ body.nav-open .main {
   &:hover {
     background: lighten($grey-md, 30%);
   }
+  .content {
+    margin-bottom: 0;
+  }
 }
 
 .content {
   color: $color-main;
   display: block;
   padding: 15px 25px 0;
+  margin-bottom: 20px;
   background-color: #fff;
   border: 1px solid $grey-lt;
   @include border-radius(4px);
@@ -194,5 +198,34 @@ body.nav-open .main {
   &:last-child {
     border: none;
     padding-bottom: 0;
+  }
+}
+
+.sidebar-nav {
+  width: 100%;
+}
+@include media-query(medium) {
+  .sidebar-nav {
+    width: 33%;
+  }
+}
+
+.sidebar-link {
+  .row {
+    &:last-child {
+      border-bottom-left-radius: 5px;
+      border-bottom-right-radius: 5px;
+    }
+    &:hover {
+    background: lighten($grey-lt, 10%);
+    }
+  }
+  a {
+  display: block;
+  padding: 10px 0;
+  color: lighten($color-main, 25%);
+    &:hover {
+      color: lighten($color-main, 5%);
+    }
   }
 }

--- a/app/assets/stylesheets/layout.css.scss
+++ b/app/assets/stylesheets/layout.css.scss
@@ -49,6 +49,10 @@ body.nav-open .main {
   .main.subnav-open & {
     left: 30px;
   }
+  .grid-unit {
+    margin-top: 15px;
+    margin-bottom: 10px;
+  }
 }
 
 .page-header.wrapper {
@@ -62,6 +66,9 @@ body.nav-open .main {
   margin: 60px 0 5px;
   h2 {
     color: lighten($color-main, 20%);
+  }
+  .grid-unit {
+    margin-bottom: 10px;
   }
 }
 

--- a/app/assets/stylesheets/modules/checkpoints.css.scss
+++ b/app/assets/stylesheets/modules/checkpoints.css.scss
@@ -6,7 +6,7 @@ h2 .unpublished-badge {
 }
 
 .track-times {
-  margin-top: -20px;
+  margin-top: -7px;
   font-size: 14px;
   // color: $color-text;
   > div {

--- a/app/views/analytics/show.html.erb
+++ b/app/views/analytics/show.html.erb
@@ -10,21 +10,29 @@
       <div><%= display_end_time(@track) %></div>
     </div>
   </div>
-  <div class="grid-unit narrow pull-right">
-    <h3 class="grid-header">Analytics > All Tracks</h3>
-    <div class="row">
-      <ul>
-        <% @classroom.tracks.each do |track| %>
-          <li class="link"><%= link_to track.name, classroom_track_analytics_path(@classroom, track) %></li>
-        <% end %>
-      </ul>
-    </div>
-    <div>
+  <div class="grid-unit narrow pull-right sidebar-nav">
+    <div class="content">
+      <h4 class="unit-header">All Tracks: Analytics</h4>
+        <div class="row">
+          <ul>
+            <% @classroom.tracks.each do |track| %>
+              <li class="sidebar-link">
+                <div class="row">
+                <%= link_to track.name, classroom_track_analytics_path(@classroom, track) %>
+                </div>
+              </li>
+            <% end %>
+          </ul>
+        </div>
+      </div>
+    <div class="content">
       <%= render 'phasing' if @track.phasing? %>
     </div>
   </div>
   <div class="grid-unit wide" id="track">
-    <div><%= render :partial => 'checkpoint', collection: @track.checkpoints %></div>
+    <div class="content">
+      <%= render :partial => 'checkpoint', collection: @track.checkpoints %>
+    </div>
   </div>
 </div>
 

--- a/app/views/analytics/show.html.erb
+++ b/app/views/analytics/show.html.erb
@@ -13,7 +13,7 @@
   <div class="grid-unit narrow pull-right sidebar-nav">
     <div class="content">
       <h4 class="unit-header">All Tracks: Analytics</h4>
-        <div class="row">
+        <div class="row" id='sidebar-links'>
           <ul>
             <% @classroom.tracks.each do |track| %>
               <li class="sidebar-link">

--- a/app/views/analytics/show.html.erb
+++ b/app/views/analytics/show.html.erb
@@ -1,6 +1,6 @@
   <div class="grid-unit whole">
     <h2><%= @track.name %></h2>
-    <h5 class="subtitle"><%= @classroom.name %></h5>
+    <h6 class="subtitle"><%= @classroom.name %></h6>
   </div>
 </div>
 <div class="wrapper">

--- a/app/views/tracks/show.html.erb
+++ b/app/views/tracks/show.html.erb
@@ -23,12 +23,16 @@
       <div><%= display_end_time(@track) %></div>
     </div>
   </div>
-  <div class="grid-unit narrow pull-right">
-    <h3 class="grid-header">All Tracks</h3>
-    <div class="row">
+  <div class="grid-unit narrow pull-right sidebar-nav">
+    <div class="content">
+      <h4 class="unit-header">All Tracks</h4>
       <ul>
         <% @tracks.each do |track| %>
-          <li class="link"><%= link_to track.name, classroom_track_path(@classroom, track) %></li>
+          <li class="sidebar-link">
+            <div class="row">
+            <%= link_to track.name, classroom_track_path(@classroom, track) %>
+            </div>
+          </li>
         <% end %>
       </ul>
     </div>


### PR DESCRIPTION
This branch styles the sidebar navigations on pages it is present (tracks show and analytics show).
- If and when you have time, I'd like help with adding a `<select>` right before the current `div.sidebar-nav`. I can conditionally hide it at larger views and show it (and hide the `div.sidebar`) at mobile views. The options would be all the links present in the `ul` in `div.sidebar-nav`.
