### PR TITLE
fixes bug where teacher help event was being tracked twice

### DIFF
--- a/app/assets/javascripts/objects/requests_list.js.coffee
+++ b/app/assets/javascripts/objects/requests_list.js.coffee
@@ -14,6 +14,5 @@
   removeRequest: (requesterId) ->
     $("#requester#{requesterId}").fadeOut 'slow', ->
       $(this).remove()
-      analytics.track "Teacher Answered Student"
       unless $('.requester').length
         $('#requesters-table').append('<tr id="placeholder"><td colspan="3">You have no students needing help!</td></tr>')

--- a/app/assets/javascripts/requesters.js.coffee
+++ b/app/assets/javascripts/requesters.js.coffee
@@ -5,3 +5,4 @@ $ ->
     # Remove student from help queue
     $('#requesters-table').on "ajax:success", '.btn-small', (e, data) ->
       Curri.RequestsList.removeRequest(data.id)
+      analytics.track "Teacher Answered Student"


### PR DESCRIPTION
Nothing major just fixing one little event bug. Since the `removeRequest`method gets called in all browsers that teachers have open, it can be called multiple times. The track event should only happen for the teacher that clicks the "remove" from help queue button.
