### PR TITLE
remove track delete link from new form

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,6 @@ gem 'pg'
 
 group :production do
   gem 'rails_12factor'
-  gem 'newrelic_rpm'
   gem 'appsignal'
   gem 'unicorn'
 end
@@ -31,6 +30,7 @@ group :development do
   gem 'guard-livereload'
 end
 
+gem 'newrelic_rpm'
 gem 'email_validator'
 gem 'bcrypt-ruby'
 gem 'foreman'

--- a/app/views/tracks/_form.html.erb
+++ b/app/views/tracks/_form.html.erb
@@ -22,6 +22,4 @@
   </div>
   <div>
     <%= f.submit class: "btn btn-primary" %>
-    <%= link_to 'Delete Track', [@classroom, @track], method: :delete, data: {confirm: "Are you sure you want to delete the track?"}, class: "danger-link", id: 'delete-track' %>
-  </div>
 <% end %>

--- a/app/views/tracks/edit.html.erb
+++ b/app/views/tracks/edit.html.erb
@@ -6,6 +6,7 @@
 <div class="wrapper edit-track-wrapper">
   <div class="grid-unit wide">
     <%= render 'form' %>
+      <%= link_to 'Delete Track', [@classroom, @track], method: :delete, data: {confirm: "Are you sure you want to delete the track?"}, class: "danger-link", id: 'delete-track' %></div>
   </div>
 </div>
 <% provide(:title, "Edit #{@track.name}") %>


### PR DESCRIPTION
Same issue as last pull request, the delete link shows up on the "new" page and clicking on it blows up the app by showing an error.
- I also moved the new relic gem so that it's available in development.
