### PR TITLE
Revealtostudents

### DIFF
--- a/app/assets/javascripts/classrooms.js.coffee
+++ b/app/assets/javascripts/classrooms.js.coffee
@@ -21,6 +21,7 @@ $ ->
     $('#new_classroom').on "ajax:success", (e, data, status, xhr) ->
       Curri.clear_modal()
       $('.grid-unit').last().after($(data.partial).fadeIn('slow'))
+      analytics.track "Teacher created classroom", classroom_id: data.id
 
     $('#new_classroom').on "ajax:error", (e, xhr, status, error) ->
       Curri.form_validations('classroom', JSON.parse(xhr.responseText))
@@ -28,6 +29,7 @@ $ ->
     $('#join_classroom').on "ajax:success", (e, data, status, xhr) ->
       Curri.clear_modal()
       $('.grid-unit').last().after($(data.partial).fadeIn('slow'))
+      analytics.track "Teacher joined classroom", classroom_id: data.id
 
     $('#join_classroom').on "ajax:error", (e, xhr, status, error) ->
       Curri.form_validations('teacher', {token: xhr.responseText})

--- a/app/assets/javascripts/classrooms.js.coffee
+++ b/app/assets/javascripts/classrooms.js.coffee
@@ -3,7 +3,11 @@ $ = jQuery
 $ ->
   # Update Header
   if $('#student-help-toggle').length
-    Curri.HelpStatus.poll()
+    Curri.channel ?= Curri.pusher.subscribe("classroom#{$('#student-help-toggle').data('classroom-id')}-requesters")
+    Curri.channel.bind 'notifyStudent', (data) ->
+      if data.requesterId == $('#student-help-toggle').data('requester-id')
+        Curri.HelpStatus.helpToggle({ help: data.HelpStatus })
+
     $('#student-help-toggle a').on 'ajax:success', (e, data) ->
       Curri.HelpStatus.helpToggle(data)
       Curri.HelpStatus.showTooltip(data)

--- a/app/assets/javascripts/objects/bar_chart.js.coffee
+++ b/app/assets/javascripts/objects/bar_chart.js.coffee
@@ -25,7 +25,7 @@
 $ = jQuery
 $.fn.barChart = (data) ->
   return @each () ->
-    $(this).find('.progress-bar-danger').parents('.progress-bar').css('width', data.zeroPercent + "%").find('.progress-bar-label').text(Math.round(data.zeroPercent) + "%")
-    $(this).find('.progress-bar-warning').parents('.progress-bar').css('width', data.onePercent + "%").find('.progress-bar-label').text(Math.round(data.onePercent) + "%")
-    $(this).find('.progress-bar-success').parents('.progress-bar').css('width', data.twoPercent + "%").find('.progress-bar-label').text(Math.round(data.twoPercent) + "%")
-    $(this).find('.progress-bar-empty').parents('.progress-bar').css('width', data.emptyPercent + "%").find('.progress-bar-label').text(Math.round(data.emptyPercent) + "%")
+    $(this).find('.progress-bar-danger').parents('.progress-bar').css('width', data.zeroPercent + "%").find('.progress-bar-label').text(data.zeroCount)
+    $(this).find('.progress-bar-warning').parents('.progress-bar').css('width', data.onePercent + "%").find('.progress-bar-label').text(data.oneCount)
+    $(this).find('.progress-bar-success').parents('.progress-bar').css('width', data.twoPercent + "%").find('.progress-bar-label').text(data.twoCount)
+    $(this).find('.progress-bar-empty').parents('.progress-bar').css('width', data.emptyPercent + "%").find('.progress-bar-label').text(data.emptyCount)

--- a/app/assets/javascripts/objects/help_status.js.coffee
+++ b/app/assets/javascripts/objects/help_status.js.coffee
@@ -3,17 +3,6 @@
     "In Help Queue": true
     "Ask for Help": false
 
-  poll: ->
-    setTimeout @request, 10000
-
-  request: ->
-    $.ajax
-      url: $('.help-toggle a').attr('href')
-      dataType: 'JSON'
-      success: (data) ->
-        Curri.HelpStatus.helpToggle(data)
-        Curri.HelpStatus.poll()
-
   helpToggle: (data) ->
     $helpLink = $(".help-toggle .help-btn")
     if data.help != Curri.HelpStatus.status[$helpLink.text()]

--- a/app/assets/javascripts/objects/help_status.js.coffee
+++ b/app/assets/javascripts/objects/help_status.js.coffee
@@ -15,7 +15,7 @@
         Curri.HelpStatus.poll()
 
   helpToggle: (data) ->
-    $helpLink = $(".help-toggle a")
+    $helpLink = $(".help-toggle .help-btn")
     if data.help != Curri.HelpStatus.status[$helpLink.text()]
       $helpLink.removeClass('in-queue ask-help')
       if data.help

--- a/app/assets/javascripts/objects/requests_list.js.coffee
+++ b/app/assets/javascripts/objects/requests_list.js.coffee
@@ -15,4 +15,4 @@
     $("#requester#{requesterId}").fadeOut 'slow', ->
       $(this).remove()
       unless $('.requester').length
-        $('#requesters-table').append('<tr id="placeholder"><td colspan="4">You have no students needing help!</td></tr>')
+        $('#requesters-table').append('<tr id="placeholder"><td colspan="4">No students need help right now.</td></tr>')

--- a/app/assets/javascripts/objects/requests_list.js.coffee
+++ b/app/assets/javascripts/objects/requests_list.js.coffee
@@ -10,9 +10,14 @@
     $placeholder = $('#placeholder')
     $placeholder.remove() if $placeholder.length
     $('#requesters-table').append(partial)
+    @hideButtons()
 
   removeRequest: (requesterId) ->
     $("#requester#{requesterId}").fadeOut 'slow', ->
       $(this).remove()
       unless $('.requester').length
         $('#requesters-table').append('<tr id="placeholder"><td colspan="4">No students need help right now.</td></tr>')
+
+  hideButtons: ->
+    if Curri.user.classrole_type == 'Student'
+      $('.request-button').parent('td').hide()

--- a/app/assets/javascripts/requesters.js.coffee
+++ b/app/assets/javascripts/requesters.js.coffee
@@ -2,6 +2,8 @@ $ = jQuery
 
 $ ->
   if $('#requesters-table').length
+    Curri.RequestsList.hideButtons()
+
     # Remove student from help queue
     $('#requesters-table').on "ajax:success", '.btn-small', (e, data) ->
       Curri.RequestsList.removeRequest(data.id)

--- a/app/assets/stylesheets/modules/navigation.css.scss
+++ b/app/assets/stylesheets/modules/navigation.css.scss
@@ -389,6 +389,10 @@ a:hover .nav-burger {
 }
 
 // students
+.view-q {
+  display: inline-block;
+  margin-right: 10px;
+}
 .help-btn {
   display: inline-block;
   border: 1px solid rgba(0,0,0,0.1);

--- a/app/assets/stylesheets/modules/navigation.css.scss
+++ b/app/assets/stylesheets/modules/navigation.css.scss
@@ -353,6 +353,10 @@ a:hover .nav-burger {
   top: 3px;
 }
 
+.help-toggle div {
+  text-align: center;
+}
+
 // teacher
 .nav-help {
   width: 30px;

--- a/app/controllers/analytics_controller.rb
+++ b/app/controllers/analytics_controller.rb
@@ -4,7 +4,7 @@ class AnalyticsController < ApplicationController
 
   def show
     @phase = Phase.new(@track, params[:phase_state] || "Realtime")
-    flash.now[:track] = { event_name: "View analytics page", properties: {classroom_id: @classroom.id, track_id: @track.id, phase_state: @phase.state } }
+    flash.now[:track] = { event_name: "View analytics page", properties: {classroom_id: @classroom.id, track_id: @track.id, phase_state: @phase.state, role: current_user.classrole_type } }
   end
 
 end

--- a/app/controllers/analytics_controller.rb
+++ b/app/controllers/analytics_controller.rb
@@ -1,6 +1,4 @@
 class AnalyticsController < ApplicationController
-
-  before_action :authorize_teacher
   before_action :get_classroom
   before_action :get_track
 

--- a/app/controllers/classrooms_controller.rb
+++ b/app/controllers/classrooms_controller.rb
@@ -13,7 +13,7 @@ class ClassroomsController < ApplicationController
 
     respond_to do |format|
       if @classroom.save
-        format.json { render json: { partial: render_to_string(partial: 'classroom.html', locals: { classroom: @classroom }) }, status: :created, location: @classroom }
+        format.json { render json: { partial: render_to_string(partial: 'classroom.html', locals: { classroom: @classroom }), id: @classroom.id }, status: :created, location: @classroom }
       else
         format.json { render json: @classroom.errors, status: :unprocessable_entity }
       end
@@ -25,7 +25,7 @@ class ClassroomsController < ApplicationController
     respond_to do |format|
       if classroom && @current_user.classrooms.exclude?(classroom)
         @current_user.classrooms << classroom
-        format.json { render json: { partial: render_to_string(partial: 'classroom.html', locals: { classroom: classroom }) }, status: :created, location: classroom }
+        format.json { render json: { partial: render_to_string(partial: 'classroom.html', locals: { classroom: classroom }), id: classroom.id }, status: :created, location: classroom }
       else
         if @current_user.classrooms.include?(classroom)
           message = 'You are already in this classroom'

--- a/app/controllers/requesters_controller.rb
+++ b/app/controllers/requesters_controller.rb
@@ -1,6 +1,6 @@
 class RequestersController < ApplicationController
 
-  before_filter :authorize_teacher, only: [:index, :remove]
+  before_filter :authorize_teacher, only: [:remove]
   before_action :get_classroom
   before_action :get_requester, except: [:index]
   respond_to :html, :json

--- a/app/controllers/requesters_controller.rb
+++ b/app/controllers/requesters_controller.rb
@@ -47,6 +47,7 @@ class RequestersController < ApplicationController
     @requester.help = false
     @requester.save
     push_to_channel
+    notify_student
     update_requesters_number(@requester.help)
 
     respond_to do |format|
@@ -68,6 +69,10 @@ class RequestersController < ApplicationController
 
   def push_to_channel
     Pusher.trigger("classroom#{@classroom.id}-requesters", 'request', { requesterPartial: render_to_string(partial: 'request', locals: { classroom: @classroom, requester: @requester }), helpStatus: @requester.help, requesterId: @requester.id })
+  end
+
+  def notify_student
+    Pusher.trigger("classroom#{@classroom.id}-requesters", 'notifyStudent', { helpStatus: @requester.help, requesterId: @requester.id })
   end
 
   def update_requesters_number(add)

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -34,7 +34,7 @@ class StudentsController < ApplicationController
       render :login, layout: "login_layout"
     else
       if @user.try(:authenticate, params[:user][:password])
-        flash[:track] = { event_name: "User joins classroom" }
+        flash[:track] = { event_name: "User joins classroom", classroom_id:  @invitation.classroom.id }
         claim_invitation
       else
         flash.now.alert = "Email or password are not correct"

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -14,7 +14,7 @@ class StudentsController < ApplicationController
     @user = User.new(user_params)
     @user.classrole = Student.create
     if @user.save
-      flash[:track] = { event_name: "Student Sign Up" }
+      flash[:track] = { event_name: "Student Sign Up", properties: {classroom_id:  @invitation.classroom.id}}
       claim_invitation
     else
       render :new, layout: "login_layout"
@@ -34,7 +34,7 @@ class StudentsController < ApplicationController
       render :login, layout: "login_layout"
     else
       if @user.try(:authenticate, params[:user][:password])
-        flash[:track] = { event_name: "User joins classroom", classroom_id:  @invitation.classroom.id }
+        flash[:track] = { event_name: "User joins classroom", properties: {classroom_id:  @invitation.classroom.id}}
         claim_invitation
       else
         flash.now.alert = "Email or password are not correct"

--- a/app/controllers/teachers_controller.rb
+++ b/app/controllers/teachers_controller.rb
@@ -13,7 +13,7 @@ class TeachersController < ApplicationController
 
     if @user.save
       sign_in(@user, true)
-      flash[:track] = { event_name: "Teacher Sign Up", email: @user.email }
+      flash[:track] = { event_name: "Teacher Sign Up" }
       redirect_to classrooms_path
     else
       render :new, layout: "login_layout"

--- a/app/controllers/teachers_controller.rb
+++ b/app/controllers/teachers_controller.rb
@@ -13,7 +13,7 @@ class TeachersController < ApplicationController
 
     if @user.save
       sign_in(@user, true)
-      flash[:track] = { event_name: "Teacher Sign Up" }
+      flash[:track] = { event_name: "Teacher Sign Up", email: @user.email }
       redirect_to classrooms_path
     else
       render :new, layout: "login_layout"

--- a/app/helpers/analytics_helper.rb
+++ b/app/helpers/analytics_helper.rb
@@ -23,11 +23,12 @@ module AnalyticsHelper
     total_count == 0 ? 0 : (count * 100.0 / total_count)
   end
 
-  def render_bar(counts)
+  def render_bar(counts, show_count=false)
     percent = counts[:count] == 0 ? '' : "#{counts[:percent].round}%"
+    content = show_count ? counts[:count] : percent
     content_tag :div, class: "progress-bar", style: "width: #{counts[:percent]}%" do
       concat(content_tag :div, '', class: "progress-bar-#{SCORE_WORD[counts[:score]]}")
-      concat(content_tag :div, percent, class: 'progress-bar-label')
+      concat(content_tag :div, content, class: 'progress-bar-label')
     end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -43,7 +43,11 @@ module ApplicationHelper
 
   def track_event(event_name, properties=nil)
     p = properties.nil? ? "" : ", #{properties.to_json}"
-    javascript_tag %Q{analytics.track("#{event_name}"#{p});}
+    javascript_tag %Q{
+      $(document).ready(function(){
+        analytics.track("#{event_name}"#{p});
+      });
+    }
   end
 
   def full_title(page_title)

--- a/app/views/analytics/_checkpoint.html.erb
+++ b/app/views/analytics/_checkpoint.html.erb
@@ -10,7 +10,7 @@
       <% end %>
     <% end %>
     <div class="analytics-bar">
-      <%= render partial: 'shared/progress_bar', locals: { ratings: @phase.ratings(checkpoint), total_count: @classroom.invitations.accepted.size } %>
+      <%= render partial: 'shared/progress_bar', locals: { ratings: @phase.ratings(checkpoint), total_count: @classroom.invitations.accepted.size, show_count: true } %>
     </div>
   </div>
   <%= hasnt_voted_box(hasnt_voted) if hasnt_voted %>

--- a/app/views/analytics/_checkpoint.html.erb
+++ b/app/views/analytics/_checkpoint.html.erb
@@ -3,9 +3,11 @@
     <div class="expectation">
       <span class="h5"><%= checkpoint.expectation %></span>
     </div>
-    <% hasnt_voted = checkpoint.hasnt_voted(@phase, @classroom) %>
-    <% if hasnt_voted %>
-      <a href="" class="students-toggle pull-right" title="Show students that haven't voted"><span class="show-icon"><%= render 'shared/show' %></span></a>
+    <% if current_user.teacher? %>
+      <% hasnt_voted = checkpoint.hasnt_voted(@phase, @classroom) %>
+      <% if hasnt_voted %>
+        <a href="" class="students-toggle pull-right" title="Show students that haven't voted"><span class="show-icon"><%= render 'shared/show' %></span></a>
+      <% end %>
     <% end %>
     <div class="analytics-bar">
       <%= render partial: 'shared/progress_bar', locals: { ratings: @phase.ratings(checkpoint), total_count: @classroom.invitations.accepted.size } %>

--- a/app/views/analytics/show.html.erb
+++ b/app/views/analytics/show.html.erb
@@ -48,5 +48,5 @@
     $("#checkpoint" + data.checkpoint).barChart(ratingsCounts);
   });
   </script>
-<% end%>
+<% end %>
 <% provide(:title, 'Analytics') %>

--- a/app/views/analytics/show.html.erb
+++ b/app/views/analytics/show.html.erb
@@ -29,24 +29,16 @@
   <div class="grid-unit wide" id="track">
     <div class="content">
       <h4 class="unit-header">Classroom Analytics</h4>
-        <% if @track.phasing? %>
-          <div class="row unit-action">
-            <h6>Choose phase</h6>
-            <%= render 'phasing' %>
-          </div>
-        <% end %>
       <%= render :partial => 'checkpoint', collection: @track.checkpoints %>
     </div>
   </div>
 </div>
 
-<% if @phase.state == 'Realtime' %>
-  <script type="text/javascript">
-  var channel = window.Curri.pusher.subscribe('track<%= @track.id %>-ratings');
-  channel.bind('rating', function(data) {
-    var ratingsCounts = Curri.RatingsCounter.init(data.ratings, data.totalCount);
-    $("#checkpoint" + data.checkpoint).barChart(ratingsCounts);
-  });
-  </script>
-<% end %>
+<script type="text/javascript">
+var channel = window.Curri.pusher.subscribe('track<%= @track.id %>-ratings');
+channel.bind('rating', function(data) {
+  var ratingsCounts = Curri.RatingsCounter.init(data.ratings, data.totalCount);
+  $("#checkpoint" + data.checkpoint).barChart(ratingsCounts);
+});
+</script>
 <% provide(:title, 'Analytics') %>

--- a/app/views/analytics/show.html.erb
+++ b/app/views/analytics/show.html.erb
@@ -28,7 +28,7 @@
   </div>
   <div class="grid-unit wide" id="track">
     <div class="content">
-      <h4 class="unit-header">Analytics: All Checkpoints</h4>
+      <h4 class="unit-header">Classroom Analytics</h4>
         <% if @track.phasing? %>
           <div class="row unit-action">
             <h6>Choose phase</h6>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,7 +7,7 @@
     <%= render 'shared/event_tracking' %>
     <script src="http://js.pusher.com/2.0/pusher.min.js"></script>
     <script type="text/javascript">
-    window.Curri.pusher = new Pusher('<%= Pusher.key %>');
+      window.Curri.pusher = new Pusher('<%= Pusher.key %>');
     </script>
     <%= csrf_meta_tags %>
     <%= favicon_link_tag %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
     <%= stylesheet_link_tag "application", media: "all" %>
     <%= render 'shared/event_tracking' %>
-    <script src="http://js.pusher.com/2.0/pusher.min.js"></script>
+    <script src="http://js.pusher.com/2.1/pusher.min.js"></script>
     <script type="text/javascript">
       window.Curri.pusher = new Pusher('<%= Pusher.key %>');
     </script>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,10 +21,10 @@
         <%= yield %>
     </div>
 
+    <%= javascript_include_tag "application" %>
+
     <% if flash[:track] %>
       <%= track_event(flash[:track][:event_name], flash[:track][:properties]) %>
     <% end %>
-
-    <%= javascript_include_tag "application" %>
   </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,12 +5,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
     <%= stylesheet_link_tag "application", media: "all" %>
     <%= render 'shared/event_tracking' %>
-    <% if current_user.teacher? %>
-      <script src="http://js.pusher.com/2.0/pusher.min.js"></script>
-      <script type="text/javascript">
-      window.Curri.pusher = new Pusher('<%= Pusher.key %>');
-      </script>
-    <% end %>
+    <script src="http://js.pusher.com/2.0/pusher.min.js"></script>
+    <script type="text/javascript">
+    window.Curri.pusher = new Pusher('<%= Pusher.key %>');
+    </script>
     <%= csrf_meta_tags %>
     <%= favicon_link_tag %>
   </head>

--- a/app/views/requesters/_request.html.erb
+++ b/app/views/requesters/_request.html.erb
@@ -1,7 +1,5 @@
 <tr class="requester" id="requester<%= requester.id %>">
   <td><%= image_tag "#{requester.gravatar}?s=56", class: 'gravatar-image' %></td><td><%= requester.full_name %></td>
   <td><%= requester.updated_at.strftime("%l:%M%P, %e %b %y") %></td>
-  <% if current_user.teacher? %>
-  <td><%= link_to 'Yes', remove_classroom_requester_path(id: requester.id, classroom_id: classroom.id), method: :patch, remote: true, class: 'btn btn-primary btn-small'%></td>
-  <% end %>
+  <td><%= link_to 'Yes', remove_classroom_requester_path(id: requester.id, classroom_id: classroom.id), method: :patch, remote: true, class: 'btn btn-primary btn-small request-button'%></td>
 </tr>

--- a/app/views/requesters/_request.html.erb
+++ b/app/views/requesters/_request.html.erb
@@ -1,5 +1,7 @@
 <tr class="requester" id="requester<%= requester.id %>">
   <td><%= image_tag "#{requester.gravatar}?s=56", class: 'gravatar-image' %></td><td><%= requester.full_name %></td>
   <td><%= requester.updated_at.strftime("%l:%M%P, %e %b %y") %></td>
+  <% if current_user.teacher? %>
   <td><%= link_to 'Yes', remove_classroom_requester_path(id: requester.id, classroom_id: classroom.id), method: :patch, remote: true, class: 'btn btn-primary btn-small'%></td>
+  <% end %>
 </tr>

--- a/app/views/requesters/index.html.erb
+++ b/app/views/requesters/index.html.erb
@@ -17,7 +17,7 @@
       </thead>
 
       <% if @requesters.empty? %>
-        <tr id="placeholder"><td colspan="4">You have no students needing help. Great job!</td></tr>
+        <tr id="placeholder"><td colspan="4">No students need help right now.</td></tr>
       <% else %>
         <% @requesters.each do |requester| %>
           <%= render partial: 'request', locals: { classroom: @classroom, requester: requester } %>

--- a/app/views/requesters/index.html.erb
+++ b/app/views/requesters/index.html.erb
@@ -10,7 +10,9 @@
         <tr>
           <th colspan="2">Student</th>
           <th>Help Requested At</th>
-          <th>Student Helped?</th>
+          <% if current_user.teacher? %>
+            <th>Student Helped?</th>
+          <% end %>
         </tr>
       </thead>
 

--- a/app/views/shared/_help_toggle.html.erb
+++ b/app/views/shared/_help_toggle.html.erb
@@ -18,7 +18,7 @@
   <% end %>
 <% else %>
   <% requester = current_user.classrole.invitations.find_by(classroom_id: @classroom.id) %>
-  <div class="help-toggle pull-right" id= "student-help-toggle">
+  <%= content_tag :div, class: 'help-toggle pull-right', id: 'student-help-toggle', data: { classroom_id: @classroom.id, requester_id: requester.id } do %>
     <% if current_user.needs_help?(@classroom) %>
       <%= link_to 'In Help Queue', classroom_requester_path(classroom_id: @classroom.id, id: requester.id), method: :patch, remote: true, class: 'help-btn in-queue' %>
     <% else %>
@@ -27,6 +27,6 @@
     <div>
       <%= link_to 'View Queue', classroom_requesters_path(@classroom) %>
     </div>
-  </div>
+  <% end %>
   <div class="student-help-tooltip strong" id="help-tooltip"></div>
 <% end %>

--- a/app/views/shared/_help_toggle.html.erb
+++ b/app/views/shared/_help_toggle.html.erb
@@ -19,14 +19,12 @@
 <% else %>
   <% requester = current_user.classrole.invitations.find_by(classroom_id: @classroom.id) %>
   <%= content_tag :div, class: 'help-toggle pull-right', id: 'student-help-toggle', data: { classroom_id: @classroom.id, requester_id: requester.id } do %>
+    <%= link_to 'View Queue', classroom_requesters_path(@classroom), class: 'view-q' %>
     <% if current_user.needs_help?(@classroom) %>
       <%= link_to 'In Help Queue', classroom_requester_path(classroom_id: @classroom.id, id: requester.id), method: :patch, remote: true, class: 'help-btn in-queue' %>
     <% else %>
       <%= link_to 'Ask for Help', classroom_requester_path(classroom_id: @classroom.id, id: requester.id), method: :patch, remote: true, class: 'help-btn ask-help' %>
     <% end %>
-    <div>
-      <%= link_to 'View Queue', classroom_requesters_path(@classroom) %>
-    </div>
   <% end %>
   <div class="student-help-tooltip strong" id="help-tooltip"></div>
 <% end %>

--- a/app/views/shared/_help_toggle.html.erb
+++ b/app/views/shared/_help_toggle.html.erb
@@ -24,6 +24,9 @@
     <% else %>
       <%= link_to 'Ask for Help', classroom_requester_path(classroom_id: @classroom.id, id: requester.id), method: :patch, remote: true, class: 'help-btn ask-help' %>
     <% end %>
+    <div>
+      <%= link_to 'View Queue', classroom_requesters_path(@classroom) %>
+    </div>
   </div>
   <div class="student-help-tooltip strong" id="help-tooltip"></div>
 <% end %>

--- a/app/views/shared/_logged_in_nav.html.erb
+++ b/app/views/shared/_logged_in_nav.html.erb
@@ -19,8 +19,13 @@
     <% end %>
   </li>
 
-  <% if current_user.teacher? %>
-    <%= render 'shared/teacher_nav' %>
+  <% if @track.try(:id)%>
+    <li>
+      <%= link_to_selected classroom_track_analytics_path(@classroom, @track), class: "nav-links" do %>
+        <span class="nav-icon nav-analytics"></span>
+        <span class="nav-label">Analytics</span>
+      <% end %>
+    </li>
   <% end %>
 <% end %>
 

--- a/app/views/shared/_progress_bar.html.erb
+++ b/app/views/shared/_progress_bar.html.erb
@@ -1,8 +1,9 @@
 <div class="progress-container">
   <div class="progress-bkgd">
-    <%= render_bar(ratings_count(ratings, total_count, 0))%>
-    <%= render_bar(ratings_count(ratings, total_count, 1))%>
-    <%= render_bar(ratings_count(ratings, total_count, 2))%>
-    <%= render_bar(no_ratings(ratings, total_count))%>
+    <% show_count ||= false %>
+    <%= render_bar(ratings_count(ratings, total_count, 0), show_count)%>
+    <%= render_bar(ratings_count(ratings, total_count, 1), show_count)%>
+    <%= render_bar(ratings_count(ratings, total_count, 2), show_count)%>
+    <%= render_bar(no_ratings(ratings, total_count), show_count)%>
   </div>
 </div>

--- a/app/views/shared/_teacher_nav.html.erb
+++ b/app/views/shared/_teacher_nav.html.erb
@@ -1,8 +1,0 @@
-<% if @track.try(:id)%>
-  <li>
-    <%= link_to_selected classroom_track_analytics_path(@classroom, @track), class: "nav-links" do %>
-      <span class="nav-icon nav-analytics"></span>
-      <span class="nav-label">Analytics</span>
-    <% end %>
-  </li>
-<% end %>

--- a/spec/javascripts/bar_chart_spec.js.coffee
+++ b/spec/javascripts/bar_chart_spec.js.coffee
@@ -34,18 +34,18 @@ describe 'BarChart jQuery Plugin', ->
     # hack to get % rather than px widths
     test.checkpoint.find('.progress').hide()
 
-  describe 'Display of percentages', ->
+  describe 'Display of counts', ->
     it 'should display percent of zero ratings', ->
-      expect(test.checkpoint.find('.progress-bar-danger + .progress-bar-label').text()).toEqual('50%')
+      expect(test.checkpoint.find('.progress-bar-danger + .progress-bar-label').text()).toEqual('2')
 
     it 'should display percent of one ratings', ->
-      expect(test.checkpoint.find('.progress-bar-warning + .progress-bar-label').text()).toEqual('25%')
+      expect(test.checkpoint.find('.progress-bar-warning + .progress-bar-label').text()).toEqual('1')
 
     it 'should display percent of two ratings', ->
-      expect(test.checkpoint.find('.progress-bar-success + .progress-bar-label').text()).toEqual('0%')
+      expect(test.checkpoint.find('.progress-bar-success + .progress-bar-label').text()).toEqual('0')
 
     it 'should display percent of no ratings', ->
-      expect(test.checkpoint.find('.progress-bar-empty + .progress-bar-label').text()).toEqual('25%')
+      expect(test.checkpoint.find('.progress-bar-empty + .progress-bar-label').text()).toEqual('1')
 
   describe 'Display of bar widths', ->
     it 'should draw red portion of bar', ->

--- a/test/helpers/analytics_helper_test.rb
+++ b/test/helpers/analytics_helper_test.rb
@@ -64,4 +64,14 @@ class AnalyticsHelperTest < ActionView::TestCase
       end
     assert_equal progress_bar, render_bar(ratings_count(ratings, @total_count, 1))
   end
+
+  test "build bars with scores" do
+    ratings = @phase.ratings(@checkpoint)
+    progress_bar =
+      content_tag :div, class: "progress-bar", style: 'width: 100.0%' do
+        concat(content_tag :div, '', class: 'progress-bar-warning')
+        concat(content_tag :div, '2', class: 'progress-bar-label')
+      end
+    assert_equal progress_bar, render_bar(ratings_count(ratings, @total_count, 1), true)
+  end
 end


### PR DESCRIPTION
We've learned a lot from the pilot and will be making some big changes soon but here are some quick changes that address some of the suggestions:
- Show the request queue to the students
- Show the analytics to the students
- Change the analytics bars back to show # of students on hover rather than a %. The % remains on the "overall" tracks view because that's cumulative data.
- Student header now updates in real time as well.

We'll need  to subscribe to the Pusher $19/month service for 100 simultaneous connections but at this point another minor monthly charge is the least of our concerns. 
