### PR TITLE
change calendar to modal, so it always shows up properly

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -8,9 +8,9 @@
  * You're free to add application-wide styles to this file and they'll appear at the top of the
  * compiled file, but it's generally better to create a new file per style scope.
  *
- *= require pickadate/classic
- *= require pickadate/classic.date
- *= require pickadate/classic.time
+ *= require pickadate/default
+ *= require pickadate/default.date
+ *= require pickadate/default.time
  *= require jquery.modal
  #= require reset
  *= require ./base


### PR DESCRIPTION
To avoid the weird scroll issue with the calendar, I just enabled the modal view for the pickadate library. Just need a quick visual check and then we're good to go.
