### PR TITLE
make request table more responsive, yes button not cut off anymore

### DIFF
--- a/app/assets/javascripts/application.js.coffee
+++ b/app/assets/javascripts/application.js.coffee
@@ -60,6 +60,7 @@ $ ->
     analytics.trackLink($('#logout-link'), "Sign out")
 
   $('a.open-modal').click ->
+    Curri.SubNav.close()
     $('.error-message').remove()
     $(this).modal(fadeDuration: 250)
     return false

--- a/app/assets/stylesheets/modules/forms.css.scss
+++ b/app/assets/stylesheets/modules/forms.css.scss
@@ -134,10 +134,10 @@ th {
   }
 }
 
-td:nth-child(2) {
-  border-left: 0;
-  text-align: left;
-}
+// td:nth-child(2) {
+//   border-left: 0;
+//   text-align: left;
+// }
 
 tbody tr {
   &:hover {

--- a/app/views/requesters/_request.html.erb
+++ b/app/views/requesters/_request.html.erb
@@ -1,5 +1,5 @@
 <tr class="requester" id="requester<%= requester.id %>">
-  <td><%= image_tag "#{requester.gravatar}?s=56", class: 'gravatar-image' %></td><td><%= requester.full_name %></td>
+  <td colspan="2"><%= image_tag "#{requester.gravatar}?s=56", class: 'gravatar-image' %><%= requester.full_name %></td>
   <td><%= requester.updated_at.strftime("%l:%M%P, %e %b %y") %></td>
   <td><%= link_to 'Yes', remove_classroom_requester_path(id: requester.id, classroom_id: classroom.id), method: :patch, remote: true, class: 'btn btn-primary btn-small request-button'%></td>
 </tr>

--- a/app/views/requesters/index.html.erb
+++ b/app/views/requesters/index.html.erb
@@ -8,8 +8,8 @@
     <table id="requesters-table">
       <thead>
         <tr>
-          <th colspan="2">Student</th>
-          <th>Help Requested At</th>
+          <th colspan="2">Name</th>
+          <th>Time</th>
           <% if current_user.teacher? %>
             <th>Student Helped?</th>
           <% end %>

--- a/app/views/students/new.html.erb
+++ b/app/views/students/new.html.erb
@@ -5,23 +5,23 @@
 <%= form_tag students_create_path, class: "form-required form-input-required" do %>
   <%= hidden_field_tag "user[token]", @token %>
   <div class="form-group">
-    <label for="email"><%= label_tag "user[email]", 'Email Address' %></label>
+    <%= label_tag "user[email]", 'Email Address' %>
     <%= email_field_tag "user[email]", nil, class: "form-input" %>
   </div>
   <div class="form-group">
-    <label for="first_name"><%= label_tag "user[first_name]", 'First Name' %></label>
+    <%= label_tag "user[first_name]", 'First Name' %>
     <%= text_field_tag "user[first_name]", nil, class: "form-input" %>
   </div>
   <div class="form-group">
-    <label for="last_name"><%= label_tag "user[last_name]", 'Last Name' %></label>
+    <%= label_tag "user[last_name]", 'Last Name' %>
     <%= text_field_tag "user[last_name]", nil, class: "form-input" %>
   </div>
   <div class="form-group">
-    <label for="pswd"><%= label_tag "user[password]", 'Password' %></label>
+    <%= label_tag "user[password]", 'Password' %>
     <%= password_field_tag "user[password]", nil, class: "form-input" %>
   </div>
   <div class="form-group">
-    <label for="pswd_conf"><%= label_tag "user[password_confirmation]", 'Password Confirmation' %></label>
+    <%= label_tag "user[password_confirmation]", 'Password Confirmation' %>
     <%= password_field_tag "user[password_confirmation]", nil, class: "form-input" %>
   </div>
   <%= submit_tag "Register", id: 'register-student', class: "btn btn-primary"%>


### PR DESCRIPTION
Already reported but Dara sent me an email yesterday saying that yeah she can't click on the "yes" button of the help queue. She also said that in landscape mode she can see the button but clicking on it doesn't do anything (a bug I haven't been able to reproduce). 

The first commit here just fixes the table a bit.
